### PR TITLE
Fixes for css breakpoints overrides & ExpansionSinglePanel creation

### DIFF
--- a/packages/svelte-materialify/src/components/ExpansionPanels/ExpansionPanel.svelte
+++ b/packages/svelte-materialify/src/components/ExpansionPanels/ExpansionPanel.svelte
@@ -5,7 +5,25 @@
   import Icon from '../Icon';
   import down from '../../internal/Icons/down';
 
-  const { values, Disabled, selectPanel, index } = getContext(EXPANSION_PANELS);
+  export let active = false;
+  export let single = false
+
+  if(!single) {
+
+    const { values, Disabled, selectPanel, index } = getContext(EXPANSION_PANELS);
+
+    const value = index();
+
+    // Inheriting the disabled value from parent.
+    $: disabled = $Disabled == null ? disabled : $Disabled;
+
+    // Checking if panel is active everytime the value has changed.
+    $: active = $values.includes(value);
+
+    function toggle() {
+      selectPanel(value);
+    }
+  }
 
   // Classes to add to the panel.
   let klass = '';
@@ -23,18 +41,6 @@
   // Styles to add to the panel.
   export let style = null;
 
-  const value = index();
-  let active = false;
-
-  function toggle() {
-    selectPanel(value);
-  }
-
-  // Inheriting the disabled value from parent.
-  $: disabled = $Disabled == null ? disabled : $Disabled;
-
-  // Checking if panel is active everytime the value has changed.
-  $: active = $values.includes(value);
 </script>
 
 <style lang="scss" src="./ExpansionPanel.scss" global>

--- a/packages/svelte-materialify/src/components/ExpansionPanels/ExpansionSinglePanel.svelte
+++ b/packages/svelte-materialify/src/components/ExpansionPanels/ExpansionSinglePanel.svelte
@@ -1,11 +1,8 @@
 <script>
-  import { getContext } from 'svelte';
-  import { EXPANSION_PANELS } from './ExpansionPanels.svelte';
+
   import { slide } from 'svelte/transition';
   import Icon from '../Icon';
   import down from '../../internal/Icons/down';
-
-  const { values, Disabled, selectPanel, index } = getContext(EXPANSION_PANELS);
 
   // Classes to add to the panel.
   let klass = '';
@@ -23,18 +20,12 @@
   // Styles to add to the panel.
   export let style = null;
 
-  const value = index();
-  let active = false;
+  export let active = false;
 
-  function toggle() {
-    selectPanel(value);
+  const toggle = () => {
+    active = !active
   }
 
-  // Inheriting the disabled value from parent.
-  $: disabled = $Disabled == null ? disabled : $Disabled;
-
-  // Checking if panel is active everytime the value has changed.
-  $: active = $values.includes(value);
 </script>
 
 <style lang="scss" src="./ExpansionPanel.scss" global>

--- a/packages/svelte-materialify/src/components/ExpansionPanels/index.js
+++ b/packages/svelte-materialify/src/components/ExpansionPanels/index.js
@@ -1,2 +1,3 @@
 export { default } from './ExpansionPanels.svelte';
 export { default as ExpansionPanel } from './ExpansionPanel.svelte';
+export { default as ExpansionSinglePanel } from './ExpansionSinglePanel.svelte';

--- a/packages/svelte-materialify/src/components/Slider/Slider.svelte
+++ b/packages/svelte-materialify/src/components/Slider/Slider.svelte
@@ -1,10 +1,10 @@
 <script>
   import Input from '../Input';
-  import { onMount, createEventDispatcher } from 'svelte';
+  import { onMount, afterUpdate, createEventDispatcher } from 'svelte';
 
   let sliderElement;
   let slider;
-  let internalValue;
+  let localValue;
   const dispatch = createEventDispatcher();
 
   export let min = 0;
@@ -70,7 +70,7 @@
     slider = sliderElement.noUiSlider;
     slider.on('update', (val, handle) => {
       value = format(val);
-      internalValue = value;
+      localValue = value;
       dispatch('update', { value: val, handle });
     });
     slider.on('change', (val, handle) => {
@@ -82,19 +82,22 @@
     };
   });
 
-  $: if (slider) {
-    if (value !== internalValue) slider.set(value, false);
-    slider.updateOptions({
-      start: value,
-      range: { min, max },
-      orientation: vertical ? 'vertical' : 'horizontal',
-      connect,
-      margin,
-      limit,
-      padding,
-      step,
-    }, false);
+  $: {
+    if (slider != null) {
+      slider.updateOptions({
+        range: { min, max },
+        orientation: vertical ? 'vertical' : 'horizontal',
+        connect,
+        margin,
+        limit,
+        padding,
+      });
+    }
   }
+
+  afterUpdate(() => {
+    if (slider && value !== localValue) slider.set(value, false);
+  });
 </script>
 
 <style lang="scss" src="./Slider.scss" global>

--- a/packages/svelte-materialify/src/components/Tooltip/Tooltip.svelte
+++ b/packages/svelte-materialify/src/components/Tooltip/Tooltip.svelte
@@ -112,11 +112,10 @@
       }
     },
   });
+
   onMount(() => {
     document.body.appendChild(tooltip);
     updateTooltipPosition();
-
-    return () => document.body.removeChild(tooltip);
   });
 </script>
 

--- a/packages/svelte-materialify/src/index.js
+++ b/packages/svelte-materialify/src/index.js
@@ -18,16 +18,9 @@ export { default as Switch } from './components/Switch';
 export { default as Radio } from './components/Radio';
 export { default as Alert } from './components/Alert';
 export { default as Chip } from './components/Chip';
-export {
-  default as DataTable,
-  DataTableHead,
-  DataTableBody,
-  DataTableRow,
-  DataTableCell,
-} from './components/DataTable';
 export { default as Dialog } from './components/Dialog';
 export { default as Divider } from './components/Divider';
-export { default as ExpansionPanels, ExpansionPanel } from './components/ExpansionPanels';
+export { default as ExpansionPanels, ExpansionPanel, ExpansionSinglePanel } from './components/ExpansionPanels';
 export { default as Avatar } from './components/Avatar';
 export { default as Badge } from './components/Badge';
 export { default as AppBar } from './components/AppBar';

--- a/packages/svelte-materialify/src/styles/_variables.scss
+++ b/packages/svelte-materialify/src/styles/_variables.scss
@@ -298,9 +298,6 @@ $material-light-theme: map-deep-merge(
       'hover': material-color('grey', 'lighten-3'),
       'group': material-color('grey', 'lighten-3'),
     ),
-    'datatables': (
-      'row-hover': rgba(material-color('shades', 'black'), 0.04),
-    ),
     'dividers': rgba(material-color('shades', 'black'), 0.12),
     'chips': #e0e0e0,
     'cards': material-color('shades', 'white'),
@@ -368,9 +365,6 @@ $material-dark-theme: map-deep-merge(
       'active': #505050,
       'hover': material-color('grey', 'darken-2'),
       'group': material-color('grey', 'darken-2'),
-    ),
-    'datatables': (
-      'row-hover': rgba(material-color('shades', 'white'), 0.04),
     ),
     'dividers': rgba(material-color('shades', 'white'), 0.12),
     'chips': #555555,


### PR DESCRIPTION
Helo,

It's my first pull request to an open source project so please be gentle if I 'm kind of clumsy

I understand that there's an ongoing rewrite so the fixes and add-ons of this pull request probably will disappear, but for now I'm trying to do some auto deploy and all css blows up, so maybe you'd like to consider it.

As I pointed out in [#230 ](https://github.com/TheComputerM/svelte-materialify/issues/230) generating classes and breakpoints in a single loop, messes the breakpoint classes overriding 
I hope this fixes all of them fixed.

Also about [#229](https://github.com/TheComputerM/svelte-materialify/issues/229) I added a new component: ExpansionSinglePanel, because modifying the original ExpansionPanel to be used in standalone mode (without the ExpansionPanels parent component) didn't look feasible to me, without messing the code way too much. Just exposing the **active** var (as a prop) looks way to "hack-ish" (and also doesn't help getting rid of the unused ExpansionPanels parent component)

If it helps, I am so glad to help. If not, please don't blame the freshman.

Thank you for your time and effort.